### PR TITLE
Fix Chain losing context with Turrets, prototype of ray turret 

### DIFF
--- a/src/main/java/io/github/derringersmods/toomanyglyphs/common/glyphs/EffectChaining.java
+++ b/src/main/java/io/github/derringersmods/toomanyglyphs/common/glyphs/EffectChaining.java
@@ -88,7 +88,7 @@ public class EffectChaining extends AbstractEffect {
             Vec3 toCenter = getBlockCenter(edge.to);
             BlockHitResult chainedRayTraceResult = new BlockHitResult(toCenter, rayTraceResult.getDirection(), edge.to,true);
             PacketRayEffect.send(world, spellContext, getBlockCenter(edge.from), getBlockCenter(edge.to));
-            SpellContext newContext = new SpellContext(continuation, shooter).withColors(spellContext.colors);
+            SpellContext newContext = new SpellContext(continuation, shooter).withType(spellContext.getType()).withCastingTile(spellContext.castingTile).withColors(spellContext.colors);
             SpellResolver.resolveEffects(world, shooter, chainedRayTraceResult, continuation, newContext);
         }
     }

--- a/src/main/java/io/github/derringersmods/toomanyglyphs/common/glyphs/MethodRay.java
+++ b/src/main/java/io/github/derringersmods/toomanyglyphs/common/glyphs/MethodRay.java
@@ -19,7 +19,6 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,12 +29,12 @@ public class MethodRay extends AbstractCastMethod {
         super(tag, description);
     }
 
-    double getRange(SpellStats stats) {
+    static double getRange(SpellStats stats) {
         return BASE_RANGE.get() + BONUS_RANGE_PER_AUGMENT.get() * stats.getBuffCount(AugmentAOE.INSTANCE);
     }
 
-    public ForgeConfigSpec.DoubleValue BASE_RANGE;
-    public ForgeConfigSpec.DoubleValue BONUS_RANGE_PER_AUGMENT;
+    public static ForgeConfigSpec.DoubleValue BASE_RANGE;
+    public static ForgeConfigSpec.DoubleValue BONUS_RANGE_PER_AUGMENT;
 
     @Override
     public void buildConfig(ForgeConfigSpec.Builder builder) {
@@ -44,12 +43,19 @@ public class MethodRay extends AbstractCastMethod {
         BONUS_RANGE_PER_AUGMENT = builder.comment("Bonus range per augment").defineInRange("bonus_range_per_augment", 16d, 0d, Double.MAX_VALUE);
     }
 
-    public void fireRay(Level world, LivingEntity shooter, SpellStats stats, SpellContext spellContext, SpellResolver resolver) {
+    public static void fireRay(Level world, LivingEntity shooter, SpellStats stats, SpellContext spellContext, SpellResolver resolver) {
         int sensitivity = stats.getBuffCount(AugmentSensitive.INSTANCE);
         double range = getRange(stats);
 
         Vec3 fromPoint = shooter.getEyePosition(1.0f);
         Vec3 toPoint = fromPoint.add(shooter.getViewVector(1.0f).scale(range));
+
+        /* the ray is not aligned with turrets, tweaks are needed to the vectors
+        if (spellContext.getType() == SpellContext.CasterType.TURRET){
+
+        }
+        */
+
         ClipContext rayTraceContext = new ClipContext(fromPoint, toPoint, sensitivity >= 1 ? ClipContext.Block.OUTLINE : ClipContext.Block.COLLIDER, sensitivity >= 2 ? ClipContext.Fluid.ANY : ClipContext.Fluid.NONE, shooter);
         BlockHitResult blockTarget = world.clip(rayTraceContext);
 

--- a/src/main/java/io/github/derringersmods/toomanyglyphs/init/ArsNouveauRegistry.java
+++ b/src/main/java/io/github/derringersmods/toomanyglyphs/init/ArsNouveauRegistry.java
@@ -1,11 +1,23 @@
 package io.github.derringersmods.toomanyglyphs.init;
 
+import com.hollingsworth.arsnouveau.api.spell.ITurretBehavior;
+import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
+import com.hollingsworth.arsnouveau.api.spell.SpellStats;
+import com.hollingsworth.arsnouveau.common.block.tile.BasicSpellTurretTile;
 import io.github.derringersmods.toomanyglyphs.common.glyphs.*;
 import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Position;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraftforge.common.util.FakePlayer;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.hollingsworth.arsnouveau.common.block.BasicSpellTurret.TURRET_BEHAVIOR_MAP;
+import static io.github.derringersmods.toomanyglyphs.common.glyphs.MethodRay.fireRay;
 
 public class ArsNouveauRegistry {
     public static List<AbstractSpellPart> registeredSpells = new ArrayList<>();
@@ -34,4 +46,16 @@ public class ArsNouveauRegistry {
         ArsNouveauAPI.getInstance().registerSpell(spellPart.getId(), spellPart);
         registeredSpells.add(spellPart);
     }
+
+    /* prototype of Ray turret
+    static {
+        TURRET_BEHAVIOR_MAP.put(MethodRay.INSTANCE, (spellResolver, basicSpellTurretTile, serverLevel, blockPos, fakePlayer, position, direction) -> {
+            SpellStats stats = new SpellStats.Builder()
+                    .setAugments(spellResolver.spell.getAugments(0, fakePlayer))
+                    .build(spellResolver.castType, null, serverLevel, fakePlayer, spellResolver.spellContext);
+            fireRay(serverLevel, fakePlayer, stats ,spellResolver.spellContext, spellResolver);
+        });
+    }
+     */
+
 }


### PR DESCRIPTION
Ray turrets are working but not really as intended, the ray height taken from the AN fakeplayer, which is as high as a player. Commented out to avoid issues.

Fixes Chain not being able to use inventories connected to the turret. ex Pickup, Blink, Place block